### PR TITLE
Add more flexible control of router-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ yarn add vue-bulma-pagination --save
 ```vue
 <template>
   <div>
-    <pagination :urlPrefix="'/'" :currentPage="2" :lastPage="100" /> 
+    <pagination :urlPrefix="'/'" :currentPage="2" :lastPage="100" />
   </div>
 </template>
 
@@ -31,16 +31,43 @@ export default {
 ```
 ## Document
 
-| props       | required | default | optional                    | desc                             |
-| ----------- | -------- | ------- | --------------------------- | -------------------------------- |
-| urlPrefix   | `false`  | '/'     |                             | urlPrefix for vue-router         |
-| currentPage | `true`   | 1       |                             |                                  |
-| lastPage    | `true`   |         |                             | the last page number             |
-| displayPage | `false`  | 4       |                             | page number will to be displayed |
-| modifiers   | `false`  | ''      | '','is-centered','is-right' |                                  |
-| prev        | `false`  | 'Prev'  |                             | text of `prev` button            |
-| next        | `false`  | 'Next'  |                             | text of `next` button            |
+| props       | required | default                   | optional                    | desc                             |
+| ----------- | -------- | --------------------------| --------------------------- | -------------------------------- |
+| urlPrefix   | `false`  | '/'                       |                             | urlPrefix for vue-router         |
+| urlBuilder  | `false`  | [urlBuilder](#urlbuilder) |                             | urlBuilder result will passed to vue-router link `to` prop        |
+| currentPage | `true`   | 1                         |                             |                                  |
+| lastPage    | `true`   |                           |                             | the last page number             |
+| displayPage | `false`  | 4                         |                             | page number will to be displayed |
+| modifiers   | `false`  | ''                        | '','is-centered','is-right' |                                  |
+| prev        | `false`  | 'Prev'                    |                             | text of `prev` button            |
+| next        | `false`  | 'Next'                    |                             | text of `next` button            |
 
+
+### urlBuilder(pageNum)
+Returned value will be passed to `router-link` as `:to` prop. See sample below:
+```vue
+<template>
+  <div class="container">
+    <pagination :urlBuilder="urlBuilder" :currentPage="2" :lastPage="100" />
+  </div>
+</template>
+
+<script>
+import Pagination from 'vue-bulma-pagination/src/Pagination'
+
+export default {
+  components: {
+    Pagination
+  },
+
+  methods: {
+    urlBuilder (page) {
+      return { query: { ...this.$route.query, page } } // Changing page in location query
+    }
+  }
+}
+</script>
+```
 
 ## Badges
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export default {
 | props       | required | default                   | optional                    | desc                             |
 | ----------- | -------- | --------------------------| --------------------------- | -------------------------------- |
 | urlPrefix   | `false`  | '/'                       |                             | urlPrefix for vue-router         |
-| urlBuilder  | `false`  | [urlBuilder](#urlbuilder) |                             | urlBuilder result will passed to vue-router link `to` prop        |
+| urlBuilder  | `false`  | [urlBuilder](#urlbuilderpagenum) |                             | urlBuilder result will passed to vue-router link `to` prop        |
 | currentPage | `true`   | 1                         |                             |                                  |
 | lastPage    | `true`   |                           |                             | the last page number             |
 | displayPage | `false`  | 4                         |                             | page number will to be displayed |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ export default {
 
 
 ### urlBuilder(pageNum)
-Returned value will be passed to `router-link` as `:to` prop. See sample below:
+Returned value will be passed to `router-link` as `:to` prop. See example below:
 ```vue
 <template>
   <div class="container">

--- a/src/Pagination.vue
+++ b/src/Pagination.vue
@@ -1,14 +1,14 @@
 <template>
     <nav :class="getNavClassName()">
-        <router-link :class="getPreClassName()" :to="normalize(urlPrefix+'/'+(formatCurrentPage-1))" >{{prev}}</router-link>
-        <router-link :class="getNextClassName()" :to="normalize(urlPrefix+'/'+(formatCurrentPage+1))">{{next}}</router-link>
+        <router-link class="pagination-previous" :to="urlBuilder(prevPage)" :disabled="outOfRegion(formatCurrentPage - 1)">{{prev}}</router-link>
+        <router-link class="pagination-next" :to="urlBuilder(nextPage)"  :disabled="outOfRegion(formatCurrentPage + 1)">{{next}}</router-link>
         <ul class="pagination-list" >
             <li v-for="item in pagingList" >
-            <router-link v-if="item !== '...'" :class=" getPagingClassName(item) " :to="normalize(urlPrefix+'/'+item)">{{ item }}</router-link>
+            <router-link v-if="item !== '...'" :class="getPagingClassName(item)" :to="urlBuilder(item)">{{ item }}</router-link>
             <span v-else class="pagination-ellipsis">...</span>
-            </li>                
+            </li>
         </ul>
-    </nav>  
+    </nav>
 </template>
 <script>
 import paging from './paging.js'
@@ -19,11 +19,17 @@ export default {
       type:String,
       default:'/'
     },
+    urlBuilder: {
+      type: Function,
+      default (page) {
+        return this.normalize(`${this.urlPrefix}/${page}`)
+      }
+    },
     currentPage: {
       type: Number,
       default: 1
     },
-    lastPage: Number,    
+    lastPage: Number,
     displayPage: {
       type: Number,
       default: 4
@@ -48,18 +54,15 @@ export default {
         return 'pagination ' + this.modifiers
       } else {
         console.warn(" modifiers %s is not within the options ", this.modifiers, optional,
-        '\n see more detail https://github.com/vue-bulma/vue-bulma-pagination#doc')  
+        '\n see more detail https://github.com/vue-bulma/vue-bulma-pagination#doc')
         return 'pagination'
-      }  
-    },  
+      }
+    },
     getPagingClassName (item) {
       return this.currentPage !== item ? 'pagination-link' : 'pagination-link is-current'
     },
-    getPreClassName () {
-      return this.currentPage !== 1 ? 'pagination-previous' : 'pagination-previous is-disabled'
-    },
-    getNextClassName () {
-      return this.currentPage < this.lastPage ? 'pagination-next' : 'pagination-next is-disabled'
+    outOfRegion (page) {
+      return page < 1 || page > this.lastPage
     },
     normalize (path) {
       return path.replace(/\/+/g,'/')
@@ -72,6 +75,12 @@ export default {
     formatCurrentPage () {
       const currentPage = Number(this.currentPage)
       return currentPage > 0 ? currentPage : 1
+    },
+    prevPage () {
+      return Math.max(this.formatCurrentPage - 1, 1)
+    },
+    nextPage () {
+      return Math.min(this.formatCurrentPage + 1, this.lastPage)
     }
   }
 }
@@ -79,7 +88,7 @@ export default {
 
 <style >
 .pagination-list {
-    list-style : none ;    
+    list-style : none ;
 }
 .pagination-list li {
     list-style : none ;


### PR DESCRIPTION
Added new prop `urlBuilder`. Result will be passed directly to `router-link` `:to` prop. More information on https://router.vuejs.org/en/api/router-link.html#props

Also fixed class `is-disabled` to HTML attribute `disabled` for 'not active' links.